### PR TITLE
Fixed the following bugs while compiling with hdf5

### DIFF
--- a/makefile
+++ b/makefile
@@ -16,7 +16,7 @@ boost : LIB = -lgsl -lgslcblas  -lboost_filesystem -lboost_system
 boost : $(EXE)
 
 hdf5 : OPT = -O3  -DUSE_BOOST -I/usr/lib/hdf5-1.8.12/hdf5/include -DUSE_HDF5
-hdf5 : LIB = -lgsl -lgslcblas -lboost_filesyste -lboost_system -lhdf5  -L/usr/lib/hdf5-1.8.12/hdf5/lib
+hdf5 : LIB = -lgsl -lgslcblas -lboost_filesystem -lboost_system -lhdf5  -L/usr/lib/hdf5-1.8.12/hdf5/lib
 hdf5 : $(EXE)
 
 warn : OPT = -O3 -Wall -Winline -Wextra

--- a/output_manager.cpp
+++ b/output_manager.cpp
@@ -828,7 +828,7 @@ void OUTPUT_MANAGER::appendIDtoFileName(char *nomefile, std::string fileName, in
 #if defined(USE_HDF5)
 
 void OUTPUT_MANAGER::writeEMFieldBinaryHDF5(std::string fileName, request req){
-  int dimensionality = mygrid->accesso.dimensions;
+  int dimensionality = mygrid->getDimensionality();
   int Ncomp = myfield->getNcomp();
 
   MPI_Info info = MPI_INFO_NULL;


### PR DESCRIPTION
make hdf5

gives a couple of errors which I fixed in my fork.

1) Typo in makefile
2) Accessing dimensions using the getDimensionality() function in output_manager.cpp
